### PR TITLE
Add train and station options

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -80,16 +80,25 @@ body {
   }
   .stationControls {
     font-size: 0.4em;
+    display: flex;
+    align-items: center;
 
     .toggleSwitchWithLabel {
       margin-right: 0.5em;
     }
   }
+
+  .card-header {
+    display: flex;
+    justify-content: center;
+
+    > :not(:first-child) {
+      margin-left: 0.75em;
+    }
+  }
 }
 
 .stationRoutes {
-  margin-left: 1em;
-
   :not(:first-child) {
     margin-left: 0.25em;
   }
@@ -302,6 +311,19 @@ body {
 
 /* Toggle Switch Styling */
 .toggleSwitchWithLabel {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+
+  .toggleSwitchWithLabel-label {
+    font-weight: bold;
+  }
+
+  .toggleSwitchWithLabel-switch {
+    display: flex;
+    align-items: center;
+  }
+
   .toggleSwitchWithLabel-prelabel {
     margin-right: 0.5em;
   }

--- a/src/App.scss
+++ b/src/App.scss
@@ -66,6 +66,27 @@ body {
   }
 }
 
+.stationsContainer {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.station {
+  &.station--half {
+    flex: 1;
+  }
+  &.station--full {
+    width: 100%;
+  }
+  .stationControls {
+    font-size: 0.4em;
+
+    .toggleSwitchWithLabel {
+      margin-right: 0.5em;
+    }
+  }
+}
+
 .stationRoutes {
   margin-left: 1em;
 

--- a/src/components/shared/label-toggle-switch.js
+++ b/src/components/shared/label-toggle-switch.js
@@ -5,13 +5,17 @@ import ToggleSwitch from "@trendmicro/react-toggle-switch";
 const ToggleSwitchWithLabel = ({
   prelabel = "",
   postlabel = "",
+  label = "",
   ...passThroughProps
 }) => {
   return (
     <span className="toggleSwitchWithLabel">
-      <span className="toggleSwitchWithLabel-prelabel">{prelabel}</span>
-      <ToggleSwitch {...passThroughProps} />
-      <span className="toggleSwitchWithLabel-postlabel">{postlabel}</span>
+      <span className="toggleSwitchWithLabel-label">{label}</span>
+      <span className="toggleSwitchWithLabel-switch">
+        <span className="toggleSwitchWithLabel-prelabel">{prelabel}</span>
+        <ToggleSwitch {...passThroughProps} />
+        <span className="toggleSwitchWithLabel-postlabel">{postlabel}</span>
+      </span>
     </span>
   );
 };

--- a/src/components/subway/station-display.js
+++ b/src/components/subway/station-display.js
@@ -133,11 +133,9 @@ const StationControls = ({
 };
 
 StationControls.propTypes = {
-  allTrains: PropTypes.bool.isRequired,
   isUptown: PropTypes.bool.isRequired,
   halfStation: PropTypes.bool.isRequired,
   toggleUptown: PropTypes.func.isRequired,
-  toggleTrainLimit: PropTypes.func.isRequired,
   toggleHalfStation: PropTypes.func.isRequired
 };
 

--- a/src/components/subway/station-display.js
+++ b/src/components/subway/station-display.js
@@ -94,7 +94,8 @@ class ValidStation extends React.Component {
     return (
       <div className={stationClass}>
         <div className="card-header text-center h3">
-          {name} {routesDisplay} <StationControls {...contolProps} />
+          <span className="station-name">{name}</span> {routesDisplay}{" "}
+          <StationControls {...contolProps} />
         </div>
         <div className="card-body">{body}</div>
       </div>
@@ -109,13 +110,14 @@ const StationControls = ({
   toggleHalfStation
 }) => {
   return (
-    <div className="stationControls mt-2">
+    <div className="stationControls">
       <ToggleSwitchWithLabel
         checked={halfStation}
         onChange={event => {
           toggleHalfStation();
         }}
-        prelabel="Full Station"
+        label="Station"
+        prelabel="Full"
         postlabel="Half"
       />
       {halfStation ? (

--- a/src/components/subway/subway-controls.js
+++ b/src/components/subway/subway-controls.js
@@ -49,9 +49,7 @@ class SubwayControls extends React.Component {
       locationDisplay = (
         <span className="locationDisplay locationDisplay--enabled">
           <HasLocationIcon />
-          <p className="locationDisplay-text">
-            Using Current Location @ {location}
-          </p>
+          <p className="locationDisplay-text">Current Location @ {location}</p>
         </span>
       );
     } else {
@@ -103,7 +101,8 @@ class SubwayControls extends React.Component {
               onChange={event => {
                 toggleTrainLimit();
               }}
-              prelabel="All Trains"
+              label="Trains"
+              prelabel="All"
               postlabel="Limit"
             />
           </ul>

--- a/src/components/subway/subway-controls.js
+++ b/src/components/subway/subway-controls.js
@@ -12,24 +12,27 @@ class SubwayControls extends React.Component {
     toggleStyle: PropTypes.func.isRequired,
     activeStyle: PropTypes.bool.isRequired,
     hasLocation: PropTypes.bool,
-    toggleMetric: PropTypes.func.isRequired,
-    useMetic: PropTypes.bool.isRequired
+    locationEnabled: PropTypes.bool,
+    location: PropTypes.object,
+    toggleTrainLimit: PropTypes.func
   };
 
   static contextTypes = {
     toggleMetric: PropTypes.func,
-    useMetic: PropTypes.bool
+    useMetic: PropTypes.bool,
+    limitTrains: PropTypes.bool
   };
 
   render() {
     const {
+      toggleTrainLimit,
       toggleStyle,
       activeStyle,
       hasLocation,
       locationEnabled,
       location: { latitude, longitude }
     } = this.props;
-    const { useMetic, toggleMetric } = this.context;
+    const { useMetic, toggleMetric, limitTrains } = this.context;
     let locationDisplay = null;
 
     if (!locationEnabled) {
@@ -92,6 +95,16 @@ class SubwayControls extends React.Component {
               }}
               prelabel="°F"
               postlabel="°C"
+            />
+          </ul>
+          <ul className="navbar-nav">
+            <ToggleSwitchWithLabel
+              checked={limitTrains}
+              onChange={event => {
+                toggleTrainLimit();
+              }}
+              prelabel="All Trains"
+              postlabel="Limit"
             />
           </ul>
           <ul className="navbar-nav">{locationDisplay}</ul>

--- a/src/components/subway/subway-dashboard.js
+++ b/src/components/subway/subway-dashboard.js
@@ -24,16 +24,19 @@ export default class SubwayDashboard extends React.Component {
     isDark: false,
     timeout: 30000,
     enabled: true,
-    comparisonTime: Date.now()
+    comparisonTime: Date.now(),
+    limitTrains: false
   };
 
   static childContextTypes = {
-    comparisonTime: PropTypes.number
+    comparisonTime: PropTypes.number,
+    limitTrains: PropTypes.bool
   };
 
   getChildContext() {
     return {
-      comparisonTime: this.state.comparisonTime
+      comparisonTime: this.state.comparisonTime,
+      limitTrains: this.state.limitTrains
     };
   }
 
@@ -63,6 +66,10 @@ export default class SubwayDashboard extends React.Component {
     }
   }
 
+  toggleTrainLimit = () => {
+    this.setState({ limitTrains: !this.state.limitTrains });
+  };
+
   updateStations(latitude, longitude) {
     this.fetchLocalStations(latitude, longitude).then(stations => {
       this.setState({
@@ -90,7 +97,7 @@ export default class SubwayDashboard extends React.Component {
   };
 
   render() {
-    const { stations, darkStyle, timeout, enabled } = this.state;
+    const { stations, darkStyle, timeout, enabled, limitTrains } = this.state;
     const {
       locationEnabled,
       hasLocation,
@@ -109,8 +116,7 @@ export default class SubwayDashboard extends React.Component {
           hasLocation={hasLocation}
           locationEnabled={locationEnabled}
           location={location}
-          useMetic={useMetic}
-          toggleMetric={toggleMetric}
+          toggleTrainLimit={this.toggleTrainLimit}
         />
         <StationDisplay stations={stations} />
         <ReactInterval


### PR DESCRIPTION
Add option for half stations if you only use one direction and want to see more stations on the screen. 
Add limiting option for only displaying 3 of each train in a direction at a given station.
Fix bug with null precipitation amount